### PR TITLE
Use Time Intervals

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -30,8 +30,8 @@
 @property (assign, nonatomic) BOOL isDebug;
 @property (assign, nonatomic) BOOL isConnectedToRemoteDebug;
 @property (assign, nonatomic) NSInteger retryCount;
-@property (assign, nonatomic) NSInteger retryInterval;
-@property (assign, nonatomic) NSInteger timeout;
+@property (assign, nonatomic) NSTimeInterval retryInterval;
+@property (assign, nonatomic) NSTimeInterval timeout;
 
 + (BNCPreferenceHelper *)preferenceHelper;
 

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -10,8 +10,8 @@
 #import "BNCConfig.h"
 #import "Branch.h"
 
-static const NSInteger DEFAULT_TIMEOUT = 5;
-static const NSInteger DEFAULT_RETRY_INTERVAL = 0;
+static const NSTimeInterval DEFAULT_TIMEOUT = 5;
+static const NSTimeInterval DEFAULT_RETRY_INTERVAL = 0;
 static const NSInteger DEFAULT_RETRY_COUNT = 1;
 
 NSString * const BRANCH_PREFS_FILE = @"BNCPreferences";

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -415,7 +415,7 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  
  @param retryInterval Number of seconds to wait between retries.
  */
-- (void)setRetryInterval:(NSInteger)retryInterval;
+- (void)setRetryInterval:(NSTimeInterval)retryInterval;
 
 /**
  Specify the max number of times to retry in the case of a Branch server error
@@ -429,7 +429,7 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  
  @param timeout Number of seconds to before a request is considered timed out.
  */
-- (void)setNetworkTimeout:(NSInteger)timeout;
+- (void)setNetworkTimeout:(NSTimeInterval)timeout;
 
 #pragma mark - Session Item methods
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -232,7 +232,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
     return self.preferenceHelper.userIdentity != nil;
 }
 
-- (void)setNetworkTimeout:(NSInteger)timeout {
+- (void)setNetworkTimeout:(NSTimeInterval)timeout {
     self.preferenceHelper.timeout = timeout;
 }
 
@@ -240,7 +240,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
     self.preferenceHelper.retryCount = maxRetries;
 }
 
-- (void)setRetryInterval:(NSInteger)retryInterval {
+- (void)setRetryInterval:(NSTimeInterval)retryInterval {
     self.preferenceHelper.retryInterval = retryInterval;
 }
 


### PR DESCRIPTION
@derrickstaten 

Since there is a desire to use non-whole second timeouts, just changed to using NSTimeIntervals.
TimeIntervals are typedef'd as doubles, so they allow non-whole numbers.
Since this is the type the NSURLRequest is expecting anyway, it's a pretty easy change to make.