### PR TITLE
Urgent: Add back in update app list

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchUpdateAppListRequest.h
+++ b/Branch-SDK/Branch-SDK/BranchUpdateAppListRequest.h
@@ -1,0 +1,15 @@
+//
+//  BranchUpdateAppListRequest.h
+//  Branch-TestBed
+//
+//  Created by Graham Mueller on 5/26/15.
+//  Copyright (c) 2015 Branch Metrics. All rights reserved.
+//
+
+#import "BNCServerRequest.h"
+
+@interface BranchUpdateAppListRequest : BNCServerRequest
+
+- (id)initWithAppList:(NSDictionary *)appList;
+
+@end

--- a/Branch-SDK/Branch-SDK/BranchUpdateAppListRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchUpdateAppListRequest.m
@@ -1,0 +1,62 @@
+//
+//  BranchUpdateAppListRequest.m
+//  Branch-TestBed
+//
+//  Created by Graham Mueller on 5/26/15.
+//  Copyright (c) 2015 Branch Metrics. All rights reserved.
+//
+
+#import "BranchUpdateAppListRequest.h"
+#import "BNCPreferenceHelper.h"
+#import "BNCSystemObserver.h"
+#import "BNCEncodingUtils.h"
+
+@interface BranchUpdateAppListRequest ()
+
+@property (strong, nonatomic) NSDictionary *appList;
+
+@end
+
+@implementation BranchUpdateAppListRequest
+
+- (id)initWithAppList:(NSDictionary *)appList {
+    if (self = [super init]) {
+        _appList = appList;
+    }
+    
+    return self;
+}
+
+- (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
+    NSDictionary *params = @{
+                             @"device_fingerprint_id": [BNCPreferenceHelper preferenceHelper].deviceFingerprintID,
+                             @"os": [BNCSystemObserver getOS],
+                             @"apps_data": self.appList
+                             };
+    
+    [serverInterface postRequest:params url:[[BNCPreferenceHelper preferenceHelper] getAPIURL:@"applist"] key:key callback:callback];
+}
+
+- (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
+    if (error) {
+        return;
+    }
+}
+
+#pragma mark - NSCoding methods
+
+- (id)initWithCoder:(NSCoder *)decoder {
+    if (self = [super initWithCoder:decoder]) {
+        _appList = [BNCEncodingUtils decodeJsonStringToDictionary:[decoder decodeObjectForKey:@"appList"]];
+    }
+    
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [super encodeWithCoder:coder];
+    
+    [coder encodeObject:[BNCEncodingUtils encodeDictionaryToJsonString:self.appList] forKey:@"appList"];
+}
+
+@end

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -360,6 +360,8 @@
 				4642E6AA1B1FA2AA006E4C1F /* BranchDisconnectDebugRequest.m */,
 				4642E6AD1B1FA303006E4C1F /* BranchLogRequest.h */,
 				4642E6AE1B1FA303006E4C1F /* BranchLogRequest.m */,
+				67830B491B676147008990EC /* BranchUpdateAppListRequest.h */,
+				67830B461B6760D4008990EC /* BranchUpdateAppListRequest.m */,
 			);
 			name = BranchRequests;
 			sourceTree = "<group>";
@@ -450,8 +452,6 @@
 				670016BD1946309100A9E103 /* Branch.h */,
 				670016BE1946309100A9E103 /* Branch.m */,
 				670016C11946309100A9E103 /* BNCPreferenceHelper.h */,
-				67830B491B676147008990EC /* BranchUpdateAppListRequest.h */,
-				67830B461B6760D4008990EC /* BranchUpdateAppListRequest.m */,
 				670016C21946309100A9E103 /* BNCPreferenceHelper.m */,
 				670016C31946309100A9E103 /* BNCServerInterface.h */,
 				670016C41946309100A9E103 /* BNCServerInterface.m */,

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -102,6 +102,9 @@
 		670016771940F51400A9E103 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 670016751940F51400A9E103 /* Main.storyboard */; };
 		6700167A1940F51400A9E103 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 670016791940F51400A9E103 /* ViewController.m */; };
 		6700167C1940F51400A9E103 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6700167B1940F51400A9E103 /* Images.xcassets */; };
+		67830B471B6760D4008990EC /* BranchUpdateAppListRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 67830B461B6760D4008990EC /* BranchUpdateAppListRequest.m */; };
+		67830B481B6760D4008990EC /* BranchUpdateAppListRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 67830B461B6760D4008990EC /* BranchUpdateAppListRequest.m */; };
+		67830B4A1B676147008990EC /* BranchUpdateAppListRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 67830B491B676147008990EC /* BranchUpdateAppListRequest.h */; };
 		7E6B3B561AA42D0E005F45BF /* Branch_SDK_Functionality_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E6B3B551AA42D0E005F45BF /* Branch_SDK_Functionality_Tests.m */; };
 		7E6B3B7F1AA44845005F45BF /* Branch_SDK_UI_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E6B3B7E1AA44845005F45BF /* Branch_SDK_UI_Tests.m */; };
 		7EC326E11A9D640F0083C5DF /* Branch_SDK_Load_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EC326E01A9D640F0083C5DF /* Branch_SDK_Load_Tests.m */; };
@@ -226,6 +229,8 @@
 		670016C41946309100A9E103 /* BNCServerInterface.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCServerInterface.m; sourceTree = "<group>"; };
 		670016C71946309100A9E103 /* BNCSystemObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCSystemObserver.h; sourceTree = "<group>"; };
 		670016C81946309100A9E103 /* BNCSystemObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCSystemObserver.m; sourceTree = "<group>"; };
+		67830B461B6760D4008990EC /* BranchUpdateAppListRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchUpdateAppListRequest.m; sourceTree = "<group>"; };
+		67830B491B676147008990EC /* BranchUpdateAppListRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchUpdateAppListRequest.h; sourceTree = "<group>"; };
 		67BBCF271A69E49A009C7DAE /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		77B4FCF3467D12C20C0AA99B /* Pods-Branch-SDK Functionality Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Branch-SDK Functionality Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Branch-SDK Functionality Tests/Pods-Branch-SDK Functionality Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		7E30BCF21A71EEEE00AC7402 /* BNCLinkData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCLinkData.h; sourceTree = "<group>"; };
@@ -445,6 +450,8 @@
 				670016BD1946309100A9E103 /* Branch.h */,
 				670016BE1946309100A9E103 /* Branch.m */,
 				670016C11946309100A9E103 /* BNCPreferenceHelper.h */,
+				67830B491B676147008990EC /* BranchUpdateAppListRequest.h */,
+				67830B461B6760D4008990EC /* BranchUpdateAppListRequest.m */,
 				670016C21946309100A9E103 /* BNCPreferenceHelper.m */,
 				670016C31946309100A9E103 /* BNCServerInterface.h */,
 				670016C41946309100A9E103 /* BNCServerInterface.m */,
@@ -561,6 +568,7 @@
 				462B50461B449DF000967B81 /* BranchDeepLinkingController.h in Headers */,
 				46946B851B26898800627BCC /* BNCServerRequest.h in Headers */,
 				466B58741B17780A00A69EDE /* BNCPreferenceHelper.h in Headers */,
+				67830B4A1B676147008990EC /* BranchUpdateAppListRequest.h in Headers */,
 				466B58791B17780A00A69EDE /* BNCConfig.h in Headers */,
 				46946BA71B2689A100627BCC /* BranchLogRequest.h in Headers */,
 				46946B9F1B2689A100627BCC /* BranchShortUrlSyncRequest.h in Headers */,
@@ -881,6 +889,7 @@
 				463F0A431B20A663004235D2 /* BranchConnectDebugRequest.m in Sources */,
 				463F0A331B20A663004235D2 /* BranchLogoutRequest.m in Sources */,
 				466B58641B17779C00A69EDE /* BNCError.m in Sources */,
+				67830B471B6760D4008990EC /* BranchUpdateAppListRequest.m in Sources */,
 				463F0A421B20A663004235D2 /* BranchInstallRequest.m in Sources */,
 				466B58661B17779C00A69EDE /* BNCServerResponse.m in Sources */,
 				466B58681B17779C00A69EDE /* BNCLinkData.m in Sources */,
@@ -905,6 +914,7 @@
 				4683F0771B20A73F00A432E7 /* PromoCodeViewController.m in Sources */,
 				4683F0761B20A73F00A432E7 /* AppDelegate.m in Sources */,
 				670016701940F51400A9E103 /* main.m in Sources */,
+				67830B481B6760D4008990EC /* BranchUpdateAppListRequest.m in Sources */,
 				46DBB4351B34792300642FC8 /* CreateDeepLinkController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Crashes are being reported when the update app list server request was
persisted pre-removal, then being retrieved post-removal. We need to
leave this in for a while so that we can retrieve the queue from disk.

@qinweigong