### PR TITLE
Conditionally defining constants for iOS 6.

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchActivityItemProvider.m
+++ b/Branch-SDK/Branch-SDK/BranchActivityItemProvider.m
@@ -10,6 +10,16 @@
 #import "Branch.h"
 #import "BNCSystemObserver.h"
 
+// Define constants so that iOS 6 won't crash. Don't care about their values since you can't
+// possible access them, just necessary for the sake of not accessing missing symbols.
+#ifndef UIActivityTypeAddToReadingList
+#define UIActivityTypeAddToReadingList @""
+#define UIActivityTypePostToFlickr @""
+#define UIActivityTypePostToVimeo @""
+#define UIActivityTypePostToTencentWeibo @""
+#define UIActivityTypeAirDrop @""
+#endif
+
 @interface BranchActivityItemProvider ()
 
 @property (strong, nonatomic) NSDictionary *params;
@@ -73,34 +83,34 @@
     NSString *channel = activityString; //default
     
     // Set to a more human readible sting if we can identify it
-    if (activityString == UIActivityTypeAssignToContact) {
+    if ([activityString isEqualToString:UIActivityTypeAssignToContact]) {
         channel = @"assign_to_contact";
-    } else if (activityString == UIActivityTypeCopyToPasteboard) {
+    } else if ([activityString isEqualToString:UIActivityTypeCopyToPasteboard]) {
         channel = @"pasteboard";
-    } else if (activityString == UIActivityTypeMail) {
+    } else if ([activityString isEqualToString:UIActivityTypeMail]) {
         channel = @"email";
-    } else if (activityString == UIActivityTypeMessage) {
+    } else if ([activityString isEqualToString:UIActivityTypeMessage]) {
         channel = @"sms";
-    } else if (activityString == UIActivityTypePostToFacebook) {
+    } else if ([activityString isEqualToString:UIActivityTypePostToFacebook]) {
         channel = @"facebook";
-    } else if (activityString == UIActivityTypePostToTwitter) {
+    } else if ([activityString isEqualToString:UIActivityTypePostToTwitter]) {
         channel = @"twitter";
-    } else if (activityString == UIActivityTypePostToWeibo) {
+    } else if ([activityString isEqualToString:UIActivityTypePostToWeibo]) {
         channel = @"weibo";
-    } else if (activityString == UIActivityTypePrint) {
+    } else if ([activityString isEqualToString:UIActivityTypePrint]) {
         channel = @"print";
-    } else if (activityString == UIActivityTypeSaveToCameraRoll) {
+    } else if ([activityString isEqualToString:UIActivityTypeSaveToCameraRoll]) {
         channel = @"camera_roll";
     } else if ([BNCSystemObserver getOSVersion].integerValue >= 7) {
-        if (activityString == UIActivityTypeAddToReadingList) {
+        if ([activityString isEqualToString:UIActivityTypeAddToReadingList]) {
             channel = @"reading_list";
-        } else if (activityString == UIActivityTypeAirDrop) {
+        } else if ([activityString isEqualToString:UIActivityTypeAirDrop]) {
             channel = @"airdrop";
-        } else if (activityString == UIActivityTypePostToFlickr) {
+        } else if ([activityString isEqualToString:UIActivityTypePostToFlickr]) {
             channel = @"flickr";
-        } else if (activityString == UIActivityTypePostToTencentWeibo) {
+        } else if ([activityString isEqualToString:UIActivityTypePostToTencentWeibo]) {
             channel = @"tencent_weibo";
-        } else if (activityString == UIActivityTypePostToVimeo) {
+        } else if ([activityString isEqualToString:UIActivityTypePostToVimeo]) {
             channel = @"vimeo";
         }
     }


### PR DESCRIPTION
@qinweigong @aaustin 
Not sure how this was working in the past, but apparently simply putting the constants inside of a version check isn't enough -- they cause a crash because they aren't defined at all for iOS 6.
This also made it apparent that we're doing an == check on strings, updated accordingly.