### PR TITLE
fix an encoding bug when json object contains non-ascii characters

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
@@ -199,7 +199,7 @@ static const short _base64DecodingTable[256] = {
 
 + (NSData *)encodeDictionaryToJsonData:(NSDictionary *)dictionary {
     NSString *jsonString = [BNCEncodingUtils encodeDictionaryToJsonString:dictionary];
-    return [NSData dataWithBytes:[jsonString UTF8String] length:jsonString.length];
+    return [NSData dataWithBytes:jsonString.UTF8String length:strlen(jsonString.UTF8String)];
 }
 
 + (NSString *)encodeDictionaryToJsonString:(NSDictionary *)dictionary {


### PR DESCRIPTION
fix #157 