### PR TITLE
capture non-branch spotlight identifiers

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.h
+++ b/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.h
@@ -11,6 +11,7 @@
 @interface BNCContentDiscoveryManager : NSObject
 
 - (NSString *)spotlightIdentifierFromActivity:(NSUserActivity *)userActivity;
+- (NSString *)standardSpotlightIdentifierFromActivity:(NSUserActivity *)userActivity;
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description;
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description callback:(callbackWithUrl)callback;

--- a/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.m
+++ b/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.m
@@ -50,6 +50,17 @@
     return nil;
 }
 
+- (NSString *)standardSpotlightIdentifierFromActivity:(NSUserActivity *)userActivity {
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
+    // CoreSpotlight version. Matched if it has our prefix, then the link identifier is just the last piece of the identifier.
+    if ([userActivity.activityType isEqualToString:CSSearchableItemActionType] && userActivity.userInfo[CSSearchableItemActivityIdentifier]) {
+        return userActivity.userInfo[CSSearchableItemActivityIdentifier];
+    }
+#endif
+    
+    return nil;
+}
+
 
 #pragma mark - Content Indexing
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -364,8 +364,14 @@ static int BNCDebugTriggerFingersSimulator = 2;
     
     if (spotlightIdentifier) {
         self.preferenceHelper.spotlightIdentifier = spotlightIdentifier;
-
+        
         [self initUserSessionAndCallCallback:YES];
+    }
+    else {
+        NSString *nonBranchSpotlightIdentifier = [self.contentDiscoveryManager standardSpotlightIdentifierFromActivity:userActivity];
+        if (nonBranchSpotlightIdentifier) {
+            self.preferenceHelper.spotlightIdentifier = nonBranchSpotlightIdentifier;
+        }
     }
     
     return spotlightIdentifier != nil;


### PR DESCRIPTION
@aaustin this only works if the dev initializes the NSUserActivity with type `CSSearchableItemActionType`. And the identifier I get back is not human readable. I got back `Hi2Ue7xN+tdtb6W6gyae2g==` from `userActivity.userInfo[CSSearchableItemActivityIdentifier]`. So while we can send this up, I'm not sure what's going on or how helpful it will be.