### PR TITLE
Clear credits on logout

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -48,6 +48,8 @@
 
 - (void)setCreditCount:(NSInteger)count;
 - (void)setCreditCount:(NSInteger)count forBucket:(NSString *)bucket;
+- (void)removeCreditCountForBucket:(NSString *)bucket;
+- (NSDictionary *)getCreditDictionary;
 - (NSInteger)getCreditCount;
 - (NSInteger)getCreditCountForBucket:(NSString *)bucket;
 

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -44,6 +44,7 @@
 - (NSString *)getBranchKey:(BOOL)isLive;
 
 - (void)clearUserCreditsAndCounts;
+- (void)clearUserCredits;
 
 - (void)setCreditCount:(NSInteger)count;
 - (void)setCreditCount:(NSInteger)count forBucket:(NSString *)bucket;

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -412,6 +412,11 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     return [self.creditsDictionary[[BRANCH_PREFS_KEY_CREDIT_BASE stringByAppendingString:bucket]] integerValue];
 }
 
+- (void)clearUserCredits {
+    self.creditsDictionary = [[NSMutableDictionary alloc] init];
+    [self setCreditCount:0 forBucket:@"default"];
+}
+
 #pragma mark - Count Storage
 
 - (NSMutableDictionary *)countsDictionary {

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -404,6 +404,23 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     [self writeObjectToDefaults:BRANCH_PREFS_KEY_CREDITS value:self.creditsDictionary];
 }
 
+- (void)removeCreditCountForBucket:(NSString *)bucket {
+    NSMutableDictionary *dictToWrite = self.creditsDictionary;
+    [dictToWrite removeObjectForKey:[BRANCH_PREFS_KEY_CREDIT_BASE stringByAppendingString:bucket]];
+
+    [self writeObjectToDefaults:BRANCH_PREFS_KEY_CREDITS value:self.creditsDictionary];
+}
+
+- (NSDictionary *)getCreditDictionary {
+    NSMutableDictionary *returnDictionary = [[NSMutableDictionary alloc] init];
+    for(NSString *key in self.creditsDictionary) {
+        NSString *cleanKey = [key stringByReplacingOccurrencesOfString:BRANCH_PREFS_KEY_CREDIT_BASE
+                                                                                     withString:@""];
+        returnDictionary[cleanKey] = self.creditsDictionary[key];
+    }
+    return returnDictionary;
+}
+
 - (NSInteger)getCreditCount {
     return [self getCreditCountForBucket:@"default"];
 }
@@ -414,7 +431,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 - (void)clearUserCredits {
     self.creditsDictionary = [[NSMutableDictionary alloc] init];
-    [self setCreditCount:0 forBucket:@"default"];
+    [self writeObjectToDefaults:BRANCH_PREFS_KEY_CREDITS value:self.creditsDictionary];
 }
 
 #pragma mark - Count Storage

--- a/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
@@ -52,8 +52,7 @@
         }
     }
     else {
-        [preferenceHelper clearUserCreditsAndCounts];
-        [preferenceHelper setCreditCount:0 forBucket:@"default"];
+        [preferenceHelper clearUserCredits];
     }
 
     if (self.callback) {

--- a/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
@@ -42,17 +42,32 @@
 
     BOOL hasUpdated = NO;
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-    if ([response.data count]) {
+    NSDictionary *currentCreditDictionary = [preferenceHelper getCreditDictionary];
+    NSArray *responseKeys = [response.data allKeys];
+    NSArray *storedKeys = [currentCreditDictionary allKeys];
+
+    if ([responseKeys count]) {
         for (NSString *key in response.data) {
-            NSInteger credits = [response.data[key] integerValue];
-            if (credits != [preferenceHelper getCreditCountForBucket:key]) {
+             NSInteger credits = [response.data[key] integerValue];
+
+             BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+             if (credits != [preferenceHelper getCreditCountForBucket:key]) {
+                 hasUpdated = YES;
+             }
+
+             [preferenceHelper setCreditCount:credits forBucket:key];
+        }
+        for(NSString *key in storedKeys) {
+            if(![response.data objectForKey:key]) {
+                [preferenceHelper removeCreditCountForBucket:key];
                 hasUpdated = YES;
             }
-            [preferenceHelper setCreditCount:credits forBucket:key];
         }
-    }
-    else {
-        [preferenceHelper clearUserCredits];
+    } else {
+        if ([storedKeys count]) {
+            [preferenceHelper clearUserCredits];
+            hasUpdated = YES;
+        }
     }
 
     if (self.callback) {

--- a/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
@@ -55,6 +55,7 @@
     }
     else {
         [preferenceHelper clearUserCreditsAndCounts];
+        [preferenceHelper setCreditCount:0 forBucket:@"default"];
     }
 
     if (self.callback) {

--- a/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
@@ -39,19 +39,24 @@
         }
         return;
     }
-    
+
     BOOL hasUpdated = NO;
-    for (NSString *key in response.data) {
-        NSInteger credits = [response.data[key] integerValue];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    if ([[response.data allKeys] count]) {
+        for (NSString *key in response.data) {
+            NSInteger credits = [response.data[key] integerValue];
         
-        BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-        if (credits != [preferenceHelper getCreditCountForBucket:key]) {
-            hasUpdated = YES;
+            if (credits != [preferenceHelper getCreditCountForBucket:key]) {
+                hasUpdated = YES;
+            }
+        
+            [preferenceHelper setCreditCount:credits forBucket:key];
         }
-        
-        [preferenceHelper setCreditCount:credits forBucket:key];
     }
-    
+    else {
+        [preferenceHelper clearUserCreditsAndCounts];
+    }
+
     if (self.callback) {
         self.callback(hasUpdated, nil);
     }

--- a/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/Requests/BranchLoadRewardsRequest.m
@@ -42,14 +42,12 @@
 
     BOOL hasUpdated = NO;
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-    if ([[response.data allKeys] count]) {
+    if ([response.data count]) {
         for (NSString *key in response.data) {
             NSInteger credits = [response.data[key] integerValue];
-        
             if (credits != [preferenceHelper getCreditCountForBucket:key]) {
                 hasUpdated = YES;
             }
-        
             [preferenceHelper setCreditCount:credits forBucket:key];
         }
     }


### PR DESCRIPTION
If response dictionary has length (1 or more buckets for credits), update shared prefs with the values, otherwise, user has no reward history. Set count to 0 for default bucket. 

@aaustin @derrickstaten 