### PR TITLE
fix race condition by moving the copy operation into the queued task

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -492,8 +492,8 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 }
 
 - (void)persistPrefsToDisk {
-    NSDictionary *persistenceDict = [self.persistenceDict copy];
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        NSDictionary *persistenceDict = [self.persistenceDict copy];
         if (![NSKeyedArchiver archiveRootObject:persistenceDict toFile:[self prefsFile]]) {
             NSLog(@"[Branch Warning] Failed to persist preferences to disk");
         }


### PR DESCRIPTION
@danwalkowski @aaustin the preference helper probably needs a rewrite at some point, as it's possible for us to persist state that's different from the preference helper's final state. I can demonstrate the race condition in person, but ultimately it's related to changing several properties on pref helper in rapid succession. It seems the queueing mechanism seen below can result in saving old preferences to disk. E.g. if 5 properties are changed in a row, and the 4th save to disk somehow occurs after the 5th save (aka they finish in opposite order), then the final state persisted will exclude the change of the 5th property. 

Note that I have to kill the app to see this issue.