### PR TITLE
Pass content expiration date through to spotlight index

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.h
+++ b/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.h
@@ -24,5 +24,7 @@
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable thumbnailUrl:(NSURL *)thumbnailUrl userInfo:(NSDictionary *)userInfo;
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable thumbnailUrl:(NSURL *)thumbnailUrl keywords:(NSSet *)keywords userInfo:(NSDictionary *)userInfo;
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable type:(NSString *)type thumbnailUrl:(NSURL *)thumbnailUrl keywords:(NSSet *)keywords userInfo:(NSDictionary *)userInfo callback:(callbackWithUrl)callback;
+- (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable type:(NSString *)type thumbnailUrl:(NSURL *)thumbnailUrl keywords:(NSSet *)keywords userInfo:(NSDictionary *)userInfo expirationDate:(NSDate *)expirationDate callback:(callbackWithUrl)callback;
+
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.m
+++ b/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.m
@@ -245,40 +245,39 @@
     self.currentUserActivity.keywords = keywords;
     [self.currentUserActivity becomeCurrent];
     
-  // Index via the CoreSpotlight strategy
-  //get the CSSearchableItem Class object
-  id CSSearchableItemClass = NSClassFromString(@"CSSearchableItem");
-  //alloc an empty instance
-  id searchableItem = [CSSearchableItemClass alloc];
-  //create-by-name a selector fot the init method we want
-  SEL initItemSelector = NSSelectorFromString(@"initWithUniqueIdentifier:domainIdentifier:attributeSet:");
-  //call the selector on the searchableItem with appropriate arguments
-  searchableItem = ((id (*)(id, SEL, NSString *, NSString *, id))[searchableItem methodForSelector:initItemSelector])(searchableItem, initItemSelector, spotlightIdentifier, BRANCH_SPOTLIGHT_PREFIX, attributes);
+    // Index via the CoreSpotlight strategy
+    //get the CSSearchableItem Class object
+    id CSSearchableItemClass = NSClassFromString(@"CSSearchableItem");
+    //alloc an empty instance
+    id searchableItem = [CSSearchableItemClass alloc];
+    //create-by-name a selector fot the init method we want
+    SEL initItemSelector = NSSelectorFromString(@"initWithUniqueIdentifier:domainIdentifier:attributeSet:");
+    //call the selector on the searchableItem with appropriate arguments
+    searchableItem = ((id (*)(id, SEL, NSString *, NSString *, id))[searchableItem methodForSelector:initItemSelector])(searchableItem, initItemSelector, spotlightIdentifier, BRANCH_SPOTLIGHT_PREFIX, attributes);
   
-  //create an assignment method to set the expiration date on the searchableItem
-  //OLD WAY OF CALLING: SEL expirationSelector = NSSelectorFromString(@"setExpirationDate:");
-  //now invoke it on the searchableItem, providing the expirationdate
-  //((void (*)(id, SEL, NSDate *))[searchableItem methodForSelector:expirationSelector])(searchableItem, expirationSelector, expirationDate);
+    //create an assignment method to set the expiration date on the searchableItem
+    //OLD WAY OF CALLING: SEL expirationSelector = NSSelectorFromString(@"setExpirationDate:");
+    //now invoke it on the searchableItem, providing the expirationdate
+    //((void (*)(id, SEL, NSDate *))[searchableItem methodForSelector:expirationSelector])(searchableItem, expirationSelector, expirationDate);
   
-  //NEW, EASIER WAY OF CALLING.  HAVE NOT TESTED ON XCode6 OR EARLIER
-  [searchableItem setExpirationDate:expirationDate];
-  NSLog(@"%@", searchableItem);
-  
-  Class CSSearchableIndexClass = NSClassFromString(@"CSSearchableIndex");
-  SEL defaultSearchableIndexSelector = NSSelectorFromString(@"defaultSearchableIndex");
-  id defaultSearchableIndex = ((id (*)(id, SEL))[CSSearchableIndexClass methodForSelector:defaultSearchableIndexSelector])(CSSearchableIndexClass, defaultSearchableIndexSelector);
-  SEL indexSearchableItemsSelector = NSSelectorFromString(@"indexSearchableItems:completionHandler:");
-  void (^__nullable completionBlock)(NSError *indexError) = ^void(NSError *__nullable indexError) {
-    if (callback) {
-      if (indexError) {
-        callback(nil, indexError);
-      }
-      else {
-        callback(url, nil);
-      }
-    }
-  };
-  ((void (*)(id, SEL, NSArray *, void (^ __nullable)(NSError * __nullable error)))[defaultSearchableIndex methodForSelector:indexSearchableItemsSelector])(defaultSearchableIndex, indexSearchableItemsSelector, @[searchableItem], completionBlock);
+    //NEW, EASIER WAY OF CALLING.  HAVE NOT TESTED ON XCode6 OR EARLIER
+    [searchableItem setExpirationDate:expirationDate];
+
+    Class CSSearchableIndexClass = NSClassFromString(@"CSSearchableIndex");
+    SEL defaultSearchableIndexSelector = NSSelectorFromString(@"defaultSearchableIndex");
+    id defaultSearchableIndex = ((id (*)(id, SEL))[CSSearchableIndexClass methodForSelector:defaultSearchableIndexSelector])(CSSearchableIndexClass, defaultSearchableIndexSelector);
+    SEL indexSearchableItemsSelector = NSSelectorFromString(@"indexSearchableItems:completionHandler:");
+    void (^__nullable completionBlock)(NSError *indexError) = ^void(NSError *__nullable indexError) {
+        if (callback) {
+            if (indexError) {
+                callback(nil, indexError);
+            }
+            else {
+                callback(url, nil);
+            }
+        }
+    };
+    ((void (*)(id, SEL, NSArray *, void (^ __nullable)(NSError * __nullable error)))[defaultSearchableIndex methodForSelector:indexSearchableItemsSelector])(defaultSearchableIndex, indexSearchableItemsSelector, @[searchableItem], completionBlock);
 #endif
 }
 

--- a/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.m
+++ b/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.m
@@ -256,12 +256,10 @@
     searchableItem = ((id (*)(id, SEL, NSString *, NSString *, id))[searchableItem methodForSelector:initItemSelector])(searchableItem, initItemSelector, spotlightIdentifier, BRANCH_SPOTLIGHT_PREFIX, attributes);
   
     //create an assignment method to set the expiration date on the searchableItem
-    //OLD WAY OF CALLING: SEL expirationSelector = NSSelectorFromString(@"setExpirationDate:");
+    SEL expirationSelector = NSSelectorFromString(@"setExpirationDate:");
     //now invoke it on the searchableItem, providing the expirationdate
-    //((void (*)(id, SEL, NSDate *))[searchableItem methodForSelector:expirationSelector])(searchableItem, expirationSelector, expirationDate);
+    ((void (*)(id, SEL, NSDate *))[searchableItem methodForSelector:expirationSelector])(searchableItem, expirationSelector, expirationDate);
   
-    //NEW, EASIER WAY OF CALLING.  HAVE NOT TESTED ON XCode6 OR EARLIER
-    [searchableItem setExpirationDate:expirationDate];
 
     Class CSSearchableIndexClass = NSClassFromString(@"CSSearchableIndex");
     SEL defaultSearchableIndexSelector = NSSelectorFromString(@"defaultSearchableIndex");

--- a/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.m
+++ b/Branch-SDK/Branch-SDK/BNCContentDiscoveryManager.m
@@ -72,46 +72,51 @@
 #pragma mark - Content Indexing
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description {
-    [self indexContentWithTitle:title description:description publiclyIndexable:NO type:(NSString *)kUTTypeGeneric thumbnailUrl:nil keywords:nil userInfo:nil callback:NULL];
+    [self indexContentWithTitle:title description:description publiclyIndexable:NO type:(NSString *)kUTTypeGeneric thumbnailUrl:nil keywords:nil userInfo:nil expirationDate:nil callback:NULL];
 }
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description callback:(callbackWithUrl)callback {
-    [self indexContentWithTitle:title description:description publiclyIndexable:NO type:(NSString *)kUTTypeGeneric thumbnailUrl:nil keywords:nil userInfo:nil callback:callback];
+    [self indexContentWithTitle:title description:description publiclyIndexable:NO type:(NSString *)kUTTypeGeneric thumbnailUrl:nil keywords:nil userInfo:nil expirationDate:nil callback:callback];
 }
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable callback:(callbackWithUrl)callback {
-    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:(NSString *)kUTTypeGeneric thumbnailUrl:nil keywords:nil userInfo:nil callback:callback];
+    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:(NSString *)kUTTypeGeneric thumbnailUrl:nil keywords:nil userInfo:nil expirationDate:nil callback:callback];
 }
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable type:(NSString *)type callback:(callbackWithUrl)callback {
-    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:nil keywords:nil userInfo:nil callback:callback];
+    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:nil keywords:nil userInfo:nil expirationDate:nil callback:callback];
 }
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable type:(NSString *)type thumbnailUrl:(NSURL *)thumbnailUrl callback:(callbackWithUrl)callback {
-    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:nil userInfo:nil callback:callback];
+    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:nil userInfo:nil expirationDate:nil callback:callback];
 }
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable type:(NSString *)type thumbnailUrl:(NSURL *)thumbnailUrl keywords:(NSSet *)keywords callback:(callbackWithUrl)callback {
-    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:nil callback:callback];
+    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:nil expirationDate:nil callback:callback];
 }
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable type:(NSString *)type thumbnailUrl:(NSURL *)thumbnailUrl keywords:(NSSet *)keywords {
-    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:nil callback:NULL];
+    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:nil expirationDate:nil callback:NULL];
 }
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable type:(NSString *)type thumbnailUrl:(NSURL *)thumbnailUrl keywords:(NSSet *)keywords userInfo:(NSDictionary *)userInfo {
-    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:userInfo callback:NULL];
+    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:userInfo expirationDate:nil callback:NULL];
 }
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable thumbnailUrl:(NSURL *)thumbnailUrl userInfo:(NSDictionary *)userInfo {
-    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:kUTTypeGeneric thumbnailUrl:thumbnailUrl keywords:nil userInfo:userInfo callback:NULL];
+    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:kUTTypeGeneric thumbnailUrl:thumbnailUrl keywords:nil userInfo:userInfo expirationDate:nil callback:NULL];
 }
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable thumbnailUrl:(NSURL *)thumbnailUrl keywords:(NSSet *)keywords userInfo:(NSDictionary *)userInfo {
-    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:kUTTypeGeneric thumbnailUrl:thumbnailUrl keywords:keywords userInfo:userInfo callback:NULL];
+    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:kUTTypeGeneric thumbnailUrl:thumbnailUrl keywords:keywords userInfo:userInfo expirationDate:nil callback:NULL];
 }
 
 - (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable type:(NSString *)type thumbnailUrl:(NSURL *)thumbnailUrl keywords:(NSSet *)keywords userInfo:(NSDictionary *)userInfo callback:(callbackWithUrl)callback {
+    [self indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:userInfo expirationDate:nil callback:callback];
+}
+
+- (void)indexContentWithTitle:(NSString *)title description:(NSString *)description publiclyIndexable:(BOOL)publiclyIndexable type:(NSString *)type thumbnailUrl:(NSURL *)thumbnailUrl keywords:(NSSet *)keywords userInfo:(NSDictionary *)userInfo expirationDate:(NSDate *)expirationDate callback:(callbackWithUrl)callback {
+
     if ([BNCSystemObserver getOSVersion].integerValue < 9) {
         if (callback) {
             callback(nil, [NSError errorWithDomain:BNCErrorDomain code:BNCVersionError userInfo:@{ NSLocalizedDescriptionKey: @"Cannot use CoreSpotlight indexing service prior to iOS 9" }]);
@@ -194,17 +199,17 @@
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
                 NSData *thumbnailData = [NSData dataWithContentsOfURL:thumbnailUrl];
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    [self indexContentWithUrl:data[BRANCH_RESPONSE_KEY_URL] spotlightIdentifier:data[BRANCH_RESPONSE_KEY_SPOTLIGHT_IDENTIFIER] title:title description:description type:typeOrDefault thumbnailUrl:thumbnailUrl thumbnailData:thumbnailData publiclyIndexable:publiclyIndexable userInfo:userInfo keywords:keywords callback:callback];
+                    [self indexContentWithUrl:data[BRANCH_RESPONSE_KEY_URL] spotlightIdentifier:data[BRANCH_RESPONSE_KEY_SPOTLIGHT_IDENTIFIER] title:title description:description type:typeOrDefault thumbnailUrl:thumbnailUrl thumbnailData:thumbnailData publiclyIndexable:publiclyIndexable userInfo:userInfo keywords:keywords expirationDate:expirationDate callback:callback];
                 });
             });
         }
         else {
-            [self indexContentWithUrl:data[BRANCH_RESPONSE_KEY_URL] spotlightIdentifier:data[BRANCH_RESPONSE_KEY_SPOTLIGHT_IDENTIFIER] title:title description:description type:typeOrDefault thumbnailUrl:thumbnailUrl thumbnailData:nil publiclyIndexable:publiclyIndexable userInfo:userInfo keywords:keywords callback:callback];
+            [self indexContentWithUrl:data[BRANCH_RESPONSE_KEY_URL] spotlightIdentifier:data[BRANCH_RESPONSE_KEY_SPOTLIGHT_IDENTIFIER] title:title description:description type:typeOrDefault thumbnailUrl:thumbnailUrl thumbnailData:nil publiclyIndexable:publiclyIndexable userInfo:userInfo keywords:keywords expirationDate:expirationDate callback:callback];
         }
     }];
 }
 
-- (void)indexContentWithUrl:(NSString *)url spotlightIdentifier:(NSString *)spotlightIdentifier title:(NSString *)title description:(NSString *)description type:(NSString *)type thumbnailUrl:(NSURL *)thumbnailUrl thumbnailData:(NSData *)thumbnailData publiclyIndexable:(BOOL)publiclyIndexable userInfo:(NSDictionary *)userInfo keywords:(NSSet *)keywords callback:(callbackWithUrl)callback {
+- (void)indexContentWithUrl:(NSString *)url spotlightIdentifier:(NSString *)spotlightIdentifier title:(NSString *)title description:(NSString *)description type:(NSString *)type thumbnailUrl:(NSURL *)thumbnailUrl thumbnailData:(NSData *)thumbnailData publiclyIndexable:(BOOL)publiclyIndexable userInfo:(NSDictionary *)userInfo keywords:(NSSet *)keywords expirationDate:(NSDate *)expirationDate callback:(callbackWithUrl)callback {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
     
     id CSSearchableItemAttributeSetClass = NSClassFromString(@"CSSearchableItemAttributeSet");
@@ -240,27 +245,40 @@
     self.currentUserActivity.keywords = keywords;
     [self.currentUserActivity becomeCurrent];
     
-    // Index via the CoreSpotlight strategy
-    id CSSearchableItemClass = NSClassFromString(@"CSSearchableItem");
-    id item = [CSSearchableItemClass alloc];
-    SEL initItemSelector = NSSelectorFromString(@"initWithUniqueIdentifier:domainIdentifier:attributeSet:");
-    item = ((id (*)(id, SEL, NSString *, NSString *, id))[item methodForSelector:initItemSelector])(item, initItemSelector, spotlightIdentifier, BRANCH_SPOTLIGHT_PREFIX, attributes);
-    
-    Class CSSearchableIndexClass = NSClassFromString(@"CSSearchableIndex");
-    SEL defaultSearchableIndexSelector = NSSelectorFromString(@"defaultSearchableIndex");
-    id defaultSearchableIndex = ((id (*)(id, SEL))[CSSearchableIndexClass methodForSelector:defaultSearchableIndexSelector])(CSSearchableIndexClass, defaultSearchableIndexSelector);
-    SEL indexSearchableItemsSelector = NSSelectorFromString(@"indexSearchableItems:completionHandler:");
-    void (^__nullable completionBlock)(NSError *indexError) = ^void(NSError *__nullable indexError) {
-        if (callback) {
-            if (indexError) {
-                callback(nil, indexError);
-            }
-            else {
-                callback(url, nil);
-            }
-        }
-    };
-    ((void (*)(id, SEL, NSArray *, void (^ __nullable)(NSError * __nullable error)))[defaultSearchableIndex methodForSelector:indexSearchableItemsSelector])(defaultSearchableIndex, indexSearchableItemsSelector, @[item], completionBlock);
+  // Index via the CoreSpotlight strategy
+  //get the CSSearchableItem Class object
+  id CSSearchableItemClass = NSClassFromString(@"CSSearchableItem");
+  //alloc an empty instance
+  id searchableItem = [CSSearchableItemClass alloc];
+  //create-by-name a selector fot the init method we want
+  SEL initItemSelector = NSSelectorFromString(@"initWithUniqueIdentifier:domainIdentifier:attributeSet:");
+  //call the selector on the searchableItem with appropriate arguments
+  searchableItem = ((id (*)(id, SEL, NSString *, NSString *, id))[searchableItem methodForSelector:initItemSelector])(searchableItem, initItemSelector, spotlightIdentifier, BRANCH_SPOTLIGHT_PREFIX, attributes);
+  
+  //create an assignment method to set the expiration date on the searchableItem
+  //OLD WAY OF CALLING: SEL expirationSelector = NSSelectorFromString(@"setExpirationDate:");
+  //now invoke it on the searchableItem, providing the expirationdate
+  //((void (*)(id, SEL, NSDate *))[searchableItem methodForSelector:expirationSelector])(searchableItem, expirationSelector, expirationDate);
+  
+  //NEW, EASIER WAY OF CALLING.  HAVE NOT TESTED ON XCode6 OR EARLIER
+  [searchableItem setExpirationDate:expirationDate];
+  NSLog(@"%@", searchableItem);
+  
+  Class CSSearchableIndexClass = NSClassFromString(@"CSSearchableIndex");
+  SEL defaultSearchableIndexSelector = NSSelectorFromString(@"defaultSearchableIndex");
+  id defaultSearchableIndex = ((id (*)(id, SEL))[CSSearchableIndexClass methodForSelector:defaultSearchableIndexSelector])(CSSearchableIndexClass, defaultSearchableIndexSelector);
+  SEL indexSearchableItemsSelector = NSSelectorFromString(@"indexSearchableItems:completionHandler:");
+  void (^__nullable completionBlock)(NSError *indexError) = ^void(NSError *__nullable indexError) {
+    if (callback) {
+      if (indexError) {
+        callback(nil, indexError);
+      }
+      else {
+        callback(url, nil);
+      }
+    }
+  };
+  ((void (*)(id, SEL, NSArray *, void (^ __nullable)(NSError * __nullable error)))[defaultSearchableIndex methodForSelector:indexSearchableItemsSelector])(defaultSearchableIndex, indexSearchableItemsSelector, @[searchableItem], completionBlock);
 #endif
 }
 

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -1296,7 +1296,23 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  @param callback Callback called with the Branch url this will fallback to.
  @warning These functions are only usable on iOS 9 or above. Earlier versions will simply receive the callback with an error.
  */
+
 - (void)createDiscoverableContentWithTitle:(NSString *)title description:(NSString *)description thumbnailUrl:(NSURL *)thumbnailUrl linkParams:(NSDictionary *)linkParams type:(NSString *)type publiclyIndexable:(BOOL)publiclyIndexable keywords:(NSSet *)keywords callback:(callbackWithUrl)callback;
+/**
+ Take the current screen and make it discoverable, adding it to Apple's Core Spotlight index. Will be public if specified. You can override the type as desired, using one of the types provided in MobileCoreServices.
+ 
+ @param title Title for the spotlight preview item.
+ @param description Description for the spotlight preview item.
+ @param thumbnailUrl Url to an image to be used for the thumnbail in spotlight.
+ @param linkParams Additional params to be added to the NSUserActivity. These will also be added to the Branch link.
+ @param publiclyIndexable Whether or not this item should be added to Apple's public search index.
+ @param type The type to use for the NSUserActivity, taken from the list of constants provided in the MobileCoreServices framework.
+ @param keywords A set of keywords to be used in Apple's search index.
+ @param expirationDate ExpirationDate after which this will not appear in Apple's search index.
+ @param callback Callback called with the Branch url this will fallback to.
+ @warning These functions are only usable on iOS 9 or above. Earlier versions will simply receive the callback with an error.
+ */
+- (void)createDiscoverableContentWithTitle:(NSString *)title description:(NSString *)description thumbnailUrl:(NSURL *)thumbnailUrl linkParams:(NSDictionary *)linkParams type:(NSString *)type publiclyIndexable:(BOOL)publiclyIndexable keywords:(NSSet *)keywords expirationDate:(NSDate *)expirationDate callback:(callbackWithUrl)callback;
 
 #pragma mark - Referral Code methods
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -850,7 +850,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
 }
 
 - (void)createDiscoverableContentWithTitle:(NSString *)title description:(NSString *)description thumbnailUrl:(NSURL *)thumbnailUrl linkParams:(NSDictionary *)linkParams type:(NSString *)type publiclyIndexable:(BOOL)publiclyIndexable keywords:(NSSet *)keywords expirationDate:(NSDate *)expirationDate callback:(callbackWithUrl)callback {
-  [self.contentDiscoveryManager indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:linkParams expirationDate:expirationDate callback:callback];
+    [self.contentDiscoveryManager indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:linkParams expirationDate:expirationDate callback:callback];
 }
 
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -96,7 +96,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
 
 + (Branch *)getInstance {
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-
+    
     // If no Branch Key
     NSString *branchKey = [preferenceHelper getBranchKey:YES];
     NSString *keyToUse = branchKey;
@@ -112,13 +112,13 @@ static int BNCDebugTriggerFingersSimulator = 2;
             NSLog(@"Usage of App Key is deprecated, please move toward using a Branch key");
         }
     }
-
+    
     return [Branch getInstanceInternal:keyToUse returnNilIfNoCurrentInstance:NO];
 }
 
 + (Branch *)getTestInstance {
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-
+    
     // If no Branch Key
     NSString *branchKey = [preferenceHelper getBranchKey:NO];
     NSString *keyToUse = branchKey;
@@ -135,13 +135,13 @@ static int BNCDebugTriggerFingersSimulator = 2;
             keyToUse = appKey;
         }
     }
-
+    
     return [Branch getInstanceInternal:keyToUse returnNilIfNoCurrentInstance:NO];
 }
 
 + (Branch *)getInstance:(NSString *)branchKey {
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
-
+    
     if ([branchKey rangeOfString:@"key_"].location != NSNotFound) {
         preferenceHelper.branchKey = branchKey;
     }
@@ -443,38 +443,38 @@ static int BNCDebugTriggerFingersSimulator = 2;
 
 - (void)logout {
     [self logoutWithCallback:nil];
-    }
+}
 
 
 - (void)logoutWithCallback:(callbackWithStatus)callback {
-  if (!self.isInitialized) {
-    NSLog(@"Branch is not initialized, cannot logout");
-    if (callback) {callback(NO, nil);}
-  }
-  
-  BranchLogoutRequest *req = [[BranchLogoutRequest alloc] initWithCallback:^(BOOL success, NSError *error) {
-    if (success) {
-      // Clear cached links
-      self.linkCache = [[BNCLinkCache alloc] init];
-      
-      if (callback) {
-        callback(YES, nil);
-      }
-      if (self.preferenceHelper.isDebug) {
-        NSLog(@"Logout Success");
-      }
-    } else /*failure*/ {
-      if (callback) {
-        callback(NO, error);
-      }
-      if (self.preferenceHelper.isDebug) {
-        NSLog(@"Logout Failure");
-      }
+    if (!self.isInitialized) {
+        NSLog(@"Branch is not initialized, cannot logout");
+        if (callback) {callback(NO, nil);}
     }
-  }];
-  
-  [self.requestQueue enqueue:req];
-  [self processNextQueueItem];
+    
+    BranchLogoutRequest *req = [[BranchLogoutRequest alloc] initWithCallback:^(BOOL success, NSError *error) {
+        if (success) {
+            // Clear cached links
+            self.linkCache = [[BNCLinkCache alloc] init];
+            
+            if (callback) {
+                callback(YES, nil);
+            }
+            if (self.preferenceHelper.isDebug) {
+                NSLog(@"Logout Success");
+            }
+        } else /*failure*/ {
+            if (callback) {
+                callback(NO, error);
+            }
+            if (self.preferenceHelper.isDebug) {
+                NSLog(@"Logout Failure");
+            }
+        }
+    }];
+    
+    [self.requestQueue enqueue:req];
+    [self processNextQueueItem];
 }
 
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -849,6 +849,11 @@ static int BNCDebugTriggerFingersSimulator = 2;
     [self.contentDiscoveryManager indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:linkParams callback:callback];
 }
 
+- (void)createDiscoverableContentWithTitle:(NSString *)title description:(NSString *)description thumbnailUrl:(NSURL *)thumbnailUrl linkParams:(NSDictionary *)linkParams type:(NSString *)type publiclyIndexable:(BOOL)publiclyIndexable keywords:(NSSet *)keywords expirationDate:(NSDate *)expirationDate callback:(callbackWithUrl)callback {
+  [self.contentDiscoveryManager indexContentWithTitle:title description:description publiclyIndexable:publiclyIndexable type:type thumbnailUrl:thumbnailUrl keywords:keywords userInfo:linkParams expirationDate:expirationDate callback:callback];
+}
+
+
 #pragma mark - Referral methods
 
 - (NSString *)getReferralUrlWithParams:(NSDictionary *)params andTags:(NSArray *)tags andChannel:(NSString *)channel {

--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.m
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.m
@@ -164,14 +164,14 @@
     else {
         publiclyIndexable = YES;
     }
-  [[Branch getInstance] createDiscoverableContentWithTitle:self.title
-                                               description:self.contentDescription
-                                              thumbnailUrl:[NSURL URLWithString:self.imageUrl]
-                                                linkParams:self.metadata.copy
-                                                      type:self.type publiclyIndexable:publiclyIndexable
-                                                  keywords:[NSSet setWithArray:self.keywords]
-                                            expirationDate:self.expirationDate
-                                                  callback:callback];
+    [[Branch getInstance] createDiscoverableContentWithTitle:self.title
+                                                 description:self.contentDescription
+                                                thumbnailUrl:[NSURL URLWithString:self.imageUrl]
+                                                  linkParams:self.metadata.copy
+                                                        type:self.type publiclyIndexable:publiclyIndexable
+                                                    keywords:[NSSet setWithArray:self.keywords]
+                                              expirationDate:self.expirationDate
+                                                    callback:callback];
 }
 
 + (BranchUniversalObject *)getBranchUniversalObjectFromDictionary:(NSDictionary *)dictionary {

--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.m
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.m
@@ -213,7 +213,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"BranchUniversalObject \n canonicalIdentifier: %@ \n title: %@ \n contentDescription: %@ \n imageUrl: %@ \n metatdata: %@ \n type: %@ \n contentIndexMode: %ld \n keywords: %@ \n expirationDate: %@", self.canonicalIdentifier, self.title, self.contentDescription, self.imageUrl, self.metadata, self.type, (long)self.contentIndexMode, self.keywords, self.expirationDate];
+    return [NSString stringWithFormat:@"BranchUniversalObject \n canonicalIdentifier: %@ \n title: %@ \n contentDescription: %@ \n imageUrl: %@ \n metadata: %@ \n type: %@ \n contentIndexMode: %ld \n keywords: %@ \n expirationDate: %@", self.canonicalIdentifier, self.title, self.contentDescription, self.imageUrl, self.metadata, self.type, (long)self.contentIndexMode, self.keywords, self.expirationDate];
 }
 
 #pragma mark - Private methods

--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.m
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.m
@@ -168,7 +168,8 @@
                                                  description:self.contentDescription
                                                 thumbnailUrl:[NSURL URLWithString:self.imageUrl]
                                                   linkParams:self.metadata.copy
-                                                        type:self.type publiclyIndexable:publiclyIndexable
+                                                        type:self.type
+                                           publiclyIndexable:publiclyIndexable
                                                     keywords:[NSSet setWithArray:self.keywords]
                                               expirationDate:self.expirationDate
                                                     callback:callback];

--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.m
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.m
@@ -47,7 +47,7 @@
         NSLog(@"[Branch Warning] a canonicalIdentifier or title are required to uniquely identify content, so could not register view.");
         return;
     }
-
+    
     [[Branch getInstance] registerViewWithParams:[self getParamsForServerRequest]
                                      andCallback:nil];
 }
@@ -64,7 +64,7 @@
         }
         return;
     }
-
+    
     [[Branch getInstance] registerViewWithParams:[self getParamsForServerRequest] andCallback:callback];
 }
 
@@ -73,7 +73,7 @@
         NSLog(@"[Branch Warning] a canonicalIdentifier or title are required to uniquely identify content, so could not generate a URL.");
         return nil;
     }
-
+    
     return [[Branch getInstance] getShortUrlWithParams:[self getParamsForServerRequestWithAddedLinkProperties:linkProperties]
                                                andTags:linkProperties.tags
                                               andAlias:linkProperties.alias
@@ -93,7 +93,7 @@
         }
         return;
     }
-
+    
     [[Branch getInstance] getShortUrlWithParams:[self getParamsForServerRequestWithAddedLinkProperties:linkProperties]
                                         andTags:linkProperties.tags
                                        andAlias:linkProperties.alias
@@ -108,7 +108,7 @@
     if (!self.canonicalIdentifier && !self.title) {
         NSLog(@"[Branch Warning] a canonicalIdentifier or title are required to uniquely identify content. In order to not break the end user experience with sharing, Branch SDK will proceed to create a URL, but content analytics may not properly include this URL.");
     }
-
+    
     NSMutableDictionary *params = [[self getParamsForServerRequestWithAddedLinkProperties:linkProperties] mutableCopy];
     if (linkProperties.matchDuration) {
         [params setObject:@(linkProperties.matchDuration) forKey:BRANCH_REQUEST_KEY_URL_DURATION];
@@ -200,7 +200,7 @@
             universalObject.contentIndexMode = ContentIndexModePublic;
         }
     }
-
+    
     if (dictionary[BRANCH_LINK_DATA_KEY_CONTENT_EXPIRATION_DATE] && [dictionary[BRANCH_LINK_DATA_KEY_CONTENT_EXPIRATION_DATE] isKindOfClass:[NSNumber class]]) {
         NSNumber *millisecondsSince1970 = dictionary[BRANCH_LINK_DATA_KEY_CONTENT_EXPIRATION_DATE];
         universalObject.expirationDate = [NSDate dateWithTimeIntervalSince1970:millisecondsSince1970.integerValue/1000];
@@ -208,7 +208,7 @@
     if (dictionary[BRANCH_LINK_DATA_KEY_KEYWORDS]) {
         universalObject.keywords = dictionary[BRANCH_LINK_DATA_KEY_KEYWORDS];
     }
-
+    
     return universalObject;
 }
 
@@ -233,7 +233,7 @@
     [self safeSetValue:self.keywords forKey:BRANCH_LINK_DATA_KEY_KEYWORDS onDict:temp];
     [self safeSetValue:@(1000 * [self.expirationDate timeIntervalSince1970]) forKey:BRANCH_LINK_DATA_KEY_CONTENT_EXPIRATION_DATE onDict:temp];
     [self safeSetValue:self.type forKey:BRANCH_LINK_DATA_KEY_CONTENT_TYPE onDict:temp];
-
+    
     [temp addEntriesFromDictionary:[self.metadata copy]];
     return [temp copy];
 }

--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.m
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.m
@@ -164,13 +164,14 @@
     else {
         publiclyIndexable = YES;
     }
-    [[Branch getInstance] createDiscoverableContentWithTitle:self.title
-                                                 description:self.contentDescription
-                                                thumbnailUrl:[NSURL URLWithString:self.imageUrl]
-                                                        type:self.type
-                                           publiclyIndexable:publiclyIndexable
-                                                    keywords:[NSSet setWithArray:self.keywords]
-                                                    callback:callback];
+  [[Branch getInstance] createDiscoverableContentWithTitle:self.title
+                                               description:self.contentDescription
+                                              thumbnailUrl:[NSURL URLWithString:self.imageUrl]
+                                                linkParams:self.metadata.copy
+                                                      type:self.type publiclyIndexable:publiclyIndexable
+                                                  keywords:[NSSet setWithArray:self.keywords]
+                                            expirationDate:self.expirationDate
+                                                  callback:callback];
 }
 
 + (BranchUniversalObject *)getBranchUniversalObjectFromDictionary:(NSDictionary *)dictionary {

--- a/Branch-TestBed/Branch-TestBed/Base.lproj/Main.storyboard
+++ b/Branch-TestBed/Branch-TestBed/Base.lproj/Main.storyboard
@@ -83,7 +83,7 @@
                                 <rect key="frame" x="16" y="292" width="288" height="61"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -137,35 +137,35 @@
                                 <rect key="frame" x="16" y="140" width="115" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="install total = " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TfH-bw-Ted">
                                 <rect key="frame" x="16" y="169" width="92" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="buy total = " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="30J-aX-oMe">
                                 <rect key="frame" x="16" y="198" width="78" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="uniques = " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iON-Lm-S5U">
                                 <rect key="frame" x="171" y="169" width="69" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="uniques = " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lat-Wk-sfX">
                                 <rect key="frame" x="171" y="198" width="69" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Vs-G2-n8k">
@@ -385,21 +385,21 @@
                                 <rect key="frame" x="16" y="103" width="57" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Frequency:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEb-HB-95q">
                                 <rect key="frame" x="16" y="64" width="80" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jbD-tO-N5p">
                                 <rect key="frame" x="239" y="24" width="65" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Expiration date" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ELA-qZ-nbU">
@@ -412,7 +412,7 @@
                                 <rect key="frame" x="17" y="215" width="69" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FoG-ZU-UE8">
@@ -457,7 +457,7 @@
                                 <rect key="frame" x="17" y="181" width="58" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -493,7 +493,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YZH-w5-wo1">
-                                <rect key="frame" x="171" y="262" width="129" height="30"/>
+                                <rect key="frame" x="20" y="307" width="129" height="30"/>
                                 <animations/>
                                 <state key="normal" title="Old share sheet">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -503,7 +503,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bMa-mu-g3R">
-                                <rect key="frame" x="20" y="262" width="129" height="30"/>
+                                <rect key="frame" x="20" y="269" width="129" height="30"/>
                                 <animations/>
                                 <state key="normal" title="New share sheet">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -513,7 +513,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AsD-k6-yAR">
-                                <rect key="frame" x="171" y="186" width="129" height="30"/>
+                                <rect key="frame" x="20" y="224" width="129" height="30"/>
                                 <animations/>
                                 <state key="normal" title="register view">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -523,7 +523,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kVv-zr-igE">
-                                <rect key="frame" x="20" y="224" width="129" height="30"/>
+                                <rect key="frame" x="19" y="181" width="129" height="30"/>
                                 <animations/>
                                 <state key="normal" title="get short url">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -533,7 +533,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LFn-Ed-7Oq">
-                                <rect key="frame" x="20" y="186" width="133" height="30"/>
+                                <rect key="frame" x="167" y="181" width="133" height="30"/>
                                 <animations/>
                                 <state key="normal" title="init universal object">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -570,6 +570,22 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="expires after" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CGr-JP-OHF">
+                                <rect key="frame" x="157" y="265" width="133" height="26"/>
+                                <animations/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Cc1-Wa-JQd">
+                                <rect key="frame" x="154" y="307" width="158" height="29"/>
+                                <animations/>
+                                <segments>
+                                    <segment title="1 min"/>
+                                    <segment title="10 mins"/>
+                                    <segment title="1 hour"/>
+                                </segments>
+                            </segmentedControl>
                         </subviews>
                         <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -577,13 +593,14 @@
                     <navigationItem key="navigationItem" title="Branch Universal Object" id="S2g-0D-B8T"/>
                     <connections>
                         <outlet property="canonicalIdentifierTextField" destination="n5M-Rp-h0z" id="mZg-1U-TXE"/>
+                        <outlet property="expires" destination="Cc1-Wa-JQd" id="OCh-Nm-DvF"/>
                         <outlet property="shortUrlTextField" destination="PhK-Cb-jar" id="i3T-Y5-OF0"/>
                         <outlet property="titleTextField" destination="4fC-Hc-8tb" id="Oyr-TI-0cc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="F7x-wt-sMJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1130" y="838"/>
+            <point key="canvasLocation" x="1049" y="809"/>
         </scene>
         <!--Credit History-->
         <scene sceneID="nTj-xn-fDL">
@@ -607,7 +624,7 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <animations/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ci6-xp-ke0">
@@ -615,7 +632,7 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <animations/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>

--- a/Branch-TestBed/Branch-TestBed/UniversalObjectViewController.h
+++ b/Branch-TestBed/Branch-TestBed/UniversalObjectViewController.h
@@ -13,4 +13,5 @@
 @property (weak, nonatomic) IBOutlet UITextField *shortUrlTextField;
 @property (weak, nonatomic) IBOutlet UITextField *canonicalIdentifierTextField;
 @property (weak, nonatomic) IBOutlet UITextField *titleTextField;
+@property (weak, nonatomic) IBOutlet UISegmentedControl *expires;
 @end

--- a/Branch-TestBed/Branch-TestBed/UniversalObjectViewController.m
+++ b/Branch-TestBed/Branch-TestBed/UniversalObjectViewController.m
@@ -17,7 +17,9 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+  
+    self.expires.selectedSegmentIndex = 0;
+
     [self.canonicalIdentifierTextField addTarget:self
                                           action:@selector(textFieldChanged:)
                                 forControlEvents:UIControlEventEditingChanged];
@@ -53,9 +55,25 @@
     self.myContent.title = self.titleTextField.text;
     self.myContent.contentDescription = @"My awesome piece of content!";
     self.myContent.imageUrl = @"https://s3-us-west-1.amazonaws.com/branchhost/mosaic_og.png";
-    
     [self.myContent addMetadataKey:@"foo" value:@"bar"];
-    
+    NSDate* timeout = nil;
+  
+  if ([self.expires selectedSegmentIndex] == 0) {
+    timeout =[[NSDate date] dateByAddingTimeInterval:(60)];  //1 minute
+    NSLog(@"\n\n##### one minute expiration time in spotlight\n");
+  } else if ([self.expires selectedSegmentIndex] == 1) {
+    timeout = [[NSDate date] dateByAddingTimeInterval:(60*10)]; // 10 minutes
+    NSLog(@"\n\n##### ten minute expiration time in spotlight\n");
+  } else {
+    timeout = [[NSDate date] dateByAddingTimeInterval:(60*60)]; //1 hour
+    NSLog(@"\n\n##### one hour expiration time in spotlight\n");
+  }
+  
+  if (timeout) {
+    self.myContent.expirationDate = timeout;
+    NSLog(@"%@", timeout);
+  }
+  
     NSLog(@"You've initialized a %@", self.myContent);
 
     [self hideKeyboard];

--- a/Branch-TestBed/Branch-TestBed/UniversalObjectViewController.m
+++ b/Branch-TestBed/Branch-TestBed/UniversalObjectViewController.m
@@ -17,9 +17,9 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-  
+    
     self.expires.selectedSegmentIndex = 0;
-
+    
     [self.canonicalIdentifierTextField addTarget:self
                                           action:@selector(textFieldChanged:)
                                 forControlEvents:UIControlEventEditingChanged];
@@ -57,25 +57,25 @@
     self.myContent.imageUrl = @"https://s3-us-west-1.amazonaws.com/branchhost/mosaic_og.png";
     [self.myContent addMetadataKey:@"foo" value:@"bar"];
     NSDate* timeout = nil;
-  
-  if ([self.expires selectedSegmentIndex] == 0) {
-    timeout =[[NSDate date] dateByAddingTimeInterval:(60)];  //1 minute
-    NSLog(@"\n\n##### one minute expiration time in spotlight\n");
-  } else if ([self.expires selectedSegmentIndex] == 1) {
-    timeout = [[NSDate date] dateByAddingTimeInterval:(60*10)]; // 10 minutes
-    NSLog(@"\n\n##### ten minute expiration time in spotlight\n");
-  } else {
-    timeout = [[NSDate date] dateByAddingTimeInterval:(60*60)]; //1 hour
-    NSLog(@"\n\n##### one hour expiration time in spotlight\n");
-  }
-  
-  if (timeout) {
-    self.myContent.expirationDate = timeout;
-    NSLog(@"%@", timeout);
-  }
-  
+    
+    if ([self.expires selectedSegmentIndex] == 0) {
+        timeout =[[NSDate date] dateByAddingTimeInterval:(60)];  //1 minute
+        NSLog(@"\n\n##### one minute expiration time in spotlight\n");
+    } else if ([self.expires selectedSegmentIndex] == 1) {
+        timeout = [[NSDate date] dateByAddingTimeInterval:(60*10)]; // 10 minutes
+        NSLog(@"\n\n##### ten minute expiration time in spotlight\n");
+    } else {
+        timeout = [[NSDate date] dateByAddingTimeInterval:(60*60)]; //1 hour
+        NSLog(@"\n\n##### one hour expiration time in spotlight\n");
+    }
+    
+    if (timeout) {
+        self.myContent.expirationDate = timeout;
+        NSLog(@"%@", timeout);
+    }
+    
     NSLog(@"You've initialized a %@", self.myContent);
-
+    
     [self hideKeyboard];
 }
 
@@ -122,7 +122,7 @@
     /**
      Synchronous call (not recommended):
      
-    [self.myContent getShortUrlWithLinkProperties:[self exampleLinkProperties]];
+     [self.myContent getShortUrlWithLinkProperties:[self exampleLinkProperties]];
      */
 }
 
@@ -140,7 +140,7 @@
     /**
      Simple Alternative:
      
-    [self.myContent listOnSpotlight];
+     [self.myContent listOnSpotlight];
      */
 }
 
@@ -153,7 +153,7 @@
     /**
      Simple alternative:
      
-    [self.myContent showShareSheetWithShareText:@"Super amazing thing I want to share!" andCallback:nil];
+     [self.myContent showShareSheetWithShareText:@"Super amazing thing I want to share!" andCallback:nil];
      */
 }
 
@@ -180,7 +180,7 @@
     /**
      If you really love the itemProvider, here's a way to get one derived from a BranchUniversalObject:
      
-    UIActivityItemProvider *itemProvider = [self.myContent getBranchActivityItemWithLinkProperties:[self exampleLinkProperties]];
+     UIActivityItemProvider *itemProvider = [self.myContent getBranchActivityItemWithLinkProperties:[self exampleLinkProperties]];
      */
     
     // Pass this in the NSArray of ActivityItems when initializing a UIActivityViewController
@@ -190,7 +190,7 @@
     if ([shareViewController respondsToSelector:@selector(popoverPresentationController)]) {
         shareViewController.popoverPresentationController.sourceView = self.view;
     }
-
+    
     // Present the share sheet!
     [self.navigationController presentViewController:shareViewController animated:YES completion:nil];
 }


### PR DESCRIPTION
Concerted effort to pass through the expiration date from the partner API to Spotlight.  This required far more changes than it ought to have.

In the end, although it -appears- that everything is correctly configured, the items do not get flushed from Spotlight, despite the correct date appearing in the mdItemExpirationDate field of the CSSearchItem.
I'm checking this in on a floating branch for further investigation.