### PR TITLE
Proposed small fix to get the team identifier working in iOS 9.2

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.m
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.m
@@ -81,39 +81,22 @@
     return [[NSBundle mainBundle] bundleIdentifier];
 }
 
-// The technique here is basically to throw an arbitrary item into the
-// keychain, pull it back out, and see what identifier was assigned to it.
-// This is largely taken from http://stackoverflow.com/a/11841898/1252541
+
+//this method uses the fact that the OS will expand symbols at runtime with their actual values
+
 + (NSString *)getTeamIdentifier {
-    NSDictionary *query = @{
-        (__bridge NSString *)kSecClass: (__bridge NSString *)kSecClassGenericPassword,
-        (__bridge NSString *)kSecAttrAccount: @"arbitrary-bnc-account",
-        (__bridge NSString *)kSecAttrService: @"",
-        (__bridge NSString *)kSecReturnAttributes: (id)kCFBooleanTrue
-    };
-
-    CFDictionaryRef result = nil;
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
-
-    if (status == errSecItemNotFound) {
-        status = SecItemAdd((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
+    NSString *teamWithDot = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"AppIdentifierPrefix"];
+    
+    //remove the trailing dot
+    if (teamWithDot) {
+        NSString* teamWithoutDot = [teamWithDot substringToIndex:[teamWithDot length]-1];
+        NSLog(@"TeamIdentifier: %@", teamWithoutDot);
+        return teamWithoutDot;
     }
-
-    if (status != errSecSuccess) {
-        return nil;
-    }
-
-    NSString *accessGroup = [(__bridge NSDictionary *)result objectForKey:(__bridge NSString *)kSecAttrAccessGroup];
-    CFRelease(result);
-
-    NSInteger firstDotIndex = [accessGroup rangeOfString:@"."].location;
-
-    if (firstDotIndex == NSNotFound) {
-        return nil;
-    }
-
-    return [accessGroup substringToIndex:firstDotIndex];
+    return @"TeamIdentifier not found";
 }
+
+
 
 + (NSString *)getCarrier {
     NSString *carrierName = nil;

--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.m
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.m
@@ -81,22 +81,13 @@
     return [[NSBundle mainBundle] bundleIdentifier];
 }
 
-
-//this method uses the fact that the OS will expand symbols at runtime with their actual values
-
 + (NSString *)getTeamIdentifier {
     NSString *teamWithDot = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"AppIdentifierPrefix"];
-    
-    //remove the trailing dot
     if (teamWithDot) {
-        NSString* teamWithoutDot = [teamWithDot substringToIndex:[teamWithDot length]-1];
-        NSLog(@"TeamIdentifier: %@", teamWithoutDot);
-        return teamWithoutDot;
+        return [teamWithDot substringToIndex:([teamWithDot length] - 1)];
     }
-    return @"TeamIdentifier not found";
+    return nil;
 }
-
-
 
 + (NSString *)getCarrier {
     NSString *carrierName = nil;

--- a/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
+++ b/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
@@ -45,6 +45,8 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>AppIdentifierPrefix</key>
+	<string>$(AppIdentifierPrefix</string>
 	<key>branch_key</key>
 	<dict>
 		<key>live</key>

--- a/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
+++ b/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
@@ -46,7 +46,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 	<key>AppIdentifierPrefix</key>
-	<string>$(AppIdentifierPrefix</string>
+	<string>$(AppIdentifierPrefix)</string>
 	<key>branch_key</key>
 	<dict>
 		<key>live</key>


### PR DESCRIPTION
We need to have a discussion about this; it seems that Apple broke access to poking around in the kSecClass:  classes, (iOS 92. latest Xcode) which we were using to get the Team ID.

I found another way, but it requires the partner to add a key to their plist.