### PR TITLE
Account for fb

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -458,6 +458,12 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  */
 - (void)disableCookieBasedMatching;
 
+/**
+ If you're using a version of the Facebook SDK that prevents application:didFinishLaunchingWithOptions: from returning
+ YES/true when a Universal Link is clicked, you should enable this option.
+ */
+- (void)accountForFacebookSDKPreventingAppLaunch;
+
 #pragma mark - Session Item methods
 
 ///--------------------

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -360,7 +360,10 @@ static int BNCDebugTriggerFingersSimulator = 2;
         else if ([options objectForKey:UIApplicationLaunchOptionsUserActivityDictionaryKey]) {
             self.preferenceHelper.isContinuingUserActivity = YES;
             if (self.accountForFacebookSDK) {
-                [self continueUserActivity:[options objectForKey:UIApplicationLaunchOptionsUserActivityDictionaryKey]];
+                id activity = [[options objectForKey:UIApplicationLaunchOptionsUserActivityDictionaryKey] objectForKey:@"UIApplicationLaunchOptionsUserActivityKey"];
+                if (activity && [activity isKindOfClass:[NSUserActivity class]]) {
+                    [self continueUserActivity:activity];
+                }
             }
         }
     }

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -84,6 +84,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
 @property (strong, nonatomic) NSMutableDictionary *deepLinkControllers;
 @property (weak, nonatomic) UIViewController *deepLinkPresentingController;
 @property (assign, nonatomic) BOOL useCookieBasedMatching;
+@property (assign, nonatomic) BOOL accountForFacebookSDK;
 
 @end
 
@@ -258,6 +259,10 @@ static int BNCDebugTriggerFingersSimulator = 2;
     self.useCookieBasedMatching = NO;
 }
 
+- (void)accountForFacebookSDKPreventingAppLaunch {
+    self.accountForFacebookSDK = YES;
+}
+
 
 #pragma mark - InitSession Permutation methods
 
@@ -354,6 +359,9 @@ static int BNCDebugTriggerFingersSimulator = 2;
         }
         else if ([options objectForKey:UIApplicationLaunchOptionsUserActivityDictionaryKey]) {
             self.preferenceHelper.isContinuingUserActivity = YES;
+            if (self.accountForFacebookSDK) {
+                [self continueUserActivity:[options objectForKey:UIApplicationLaunchOptionsUserActivityDictionaryKey]];
+            }
         }
     }
     else {


### PR DESCRIPTION
@danwalkowski for developers who use the latest Facebook SDK and want to allow it to return `NO` for `application:didFinishLaunchingWithOptions:`. Tested by both myself and the Gogobot team, this works.