### PR TITLE
first pass - whitelist bundle ID of slack to prevent premature link c…

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchActivityItemProvider.m
+++ b/Branch-SDK/Branch-SDK/BranchActivityItemProvider.m
@@ -70,7 +70,7 @@
     }
     
     // Because Facebook immediately scrapes URLs, we add an additional parameter to the existing list, telling the backend to ignore the first click
-    if ([channel isEqualToString:@"facebook"] || [channel isEqualToString:@"twitter"]) {
+    if ([channel isEqualToString:@"facebook"] || [channel isEqualToString:@"twitter"]  || [channel isEqualToString:@"com.tinyspeck.chatlyio.share"]) {
         return [NSURL URLWithString:[[Branch getInstance] getShortURLWithParams:params andTags:tags andChannel:channel andFeature:feature andStage:stage andAlias:alias ignoreUAString:self.userAgentString forceLinkCreation:YES]];
     }
     


### PR DESCRIPTION
…lick

@derrickstaten @danwalkowski 

we simply whitelist the bundle ID for the slack app when sharing links to slack. without this whitelist, a shared link to slack generates a click automatically without anyone doing anything. upon backgrounded and re-opening the app, deep link data appears (again, without a click).

this fix prevents that