### PR TITLE
launchOptions are required

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -242,43 +242,12 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
 ///---------------------
 
 /**
- Just initialize the Branch session.
- 
- @warning This is not the recommended method of initializing Branch, as you potentially lose deep linking info, and any ability to do anything with the callback.
- */
-- (void)initSession;
-
-/**
  Just initialize the Branch session with the app launch options.
  
  @param options The launch options provided by the AppDelegate's `didFinishLaunchingWithOptions:` method.
  @warning This is not the recommended method of initializing Branch. While Branch is able to properly attribute deep linking info with the launch options, you lose the ability to do anything with a callback.
  */
 - (void)initSessionWithLaunchOptions:(NSDictionary *)options;
-
-/**
- Just initialize the Branch session, specifying whether to allow it to be treated as a referral.
- 
- @param isReferrable Boolean representing whether to allow the session to be marked as referred, overriding the default behavior.
- @warning This is not the recommended method of initializing Branch, as you potentially lose deep linking info, and any ability to do anything with the callback.
- */
-- (void)initSession:(BOOL)isReferrable;
-
-/**
- Just initialize the Branch session, specifying whether to allow it to automatically display matching deep linked controllers
- 
- @param automaticallyDisplayController Boolean indicating whether we will automatically launch into deep linked controller matched in the init session dictionary.
- @warning This is not the recommended method of initializing Branch, as you potentially lose deep linking info by not passing the launch options.
- */
-- (void)initSessionAndAutomaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController;
-
-/**
- Initialize the Branch session and handle the completion with a callback
- 
- @param callback A callback that is called when the session is opened. This will be called multiple times during the apps life, including any time the app goes through a background / foreground cycle.
- @warning This is not the recommended method of initializing Branch, as you potentially lose deep linking info by not passing the launch options.
- */
-- (void)initSessionAndRegisterDeepLinkHandler:(callbackWithParams)callback;
 
 /**
  Just initialize the Branch session with the app launch options, specifying whether to allow it to be treated as a referral.
@@ -288,15 +257,6 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  @warning This is not the recommended method of initializing Branch. While Branch is able to properly attribute deep linking info with the launch options, you lose the ability to do anything with a callback.
  */
 - (void)initSessionWithLaunchOptions:(NSDictionary *)options isReferrable:(BOOL)isReferrable;
-
-/**
- Initialize the Branch session and handle the completion with a callback
- 
- @param isReferrable Boolean representing whether to allow the session to be marked as referred, overriding the default behavior.
- @param callback A callback that is called when the session is opened. This will be called multiple times during the apps life, including any time the app goes through a background / foreground cycle.
- @warning This is not the recommended method of initializing Branch, as you potentially lose deep linking info by not passing the launch options.
- */
-- (void)initSession:(BOOL)isReferrable andRegisterDeepLinkHandler:(callbackWithParams)callback;
 
 /**
  Initialize the Branch session with the app launch options and handle the completion with a callback
@@ -321,24 +281,6 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  @param automaticallyDisplayController Boolean indicating whether we will automatically launch into deep linked controller matched in the init session dictionary.
  */
 - (void)initSessionWithLaunchOptions:(NSDictionary *)options automaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController;
-
-/**
- Initialize the Branch session and handle the completion with a callback
- 
- @param isReferrable Boolean representing whether to allow the session to be marked as referred, overriding the default behavior.
- @param automaticallyDisplayController Boolean indicating whether we will automatically launch into deep linked controller matched in the init session dictionary.
- @warning This is not the recommended method of initializing Branch, as you potentially lose deep linking info by not passing the launch options.
- */
-- (void)initSession:(BOOL)isReferrable automaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController;
-
-/**
- Initialize the Branch session and handle the completion with a callback
- 
- @param automaticallyDisplayController Boolean indicating whether we will automatically launch into deep linked controller matched in the init session dictionary.
- @param callback A callback that is called when the session is opened. This will be called multiple times during the apps life, including any time the app goes through a background / foreground cycle.
- @warning This is not the recommended method of initializing Branch, as you potentially lose deep linking info by not passing the launch options.
- */
-- (void)initSessionAndAutomaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController deepLinkHandler:(callbackWithParams)callback;
 
 /**
  Initialize the Branch session with the app launch options and handle the completion with a callback
@@ -366,16 +308,6 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  @param callback A callback that is called when the session is opened. This will be called multiple times during the apps life, including any time the app goes through a background / foreground cycle.
  */
 - (void)initSessionWithLaunchOptions:(NSDictionary *)options automaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController deepLinkHandler:(callbackWithParams)callback;
-
-/**
- Initialize the Branch session with the app launch options and handle the completion with a callback
- 
- @param automaticallyDisplayController Boolean indicating whether we will automatically launch into deep linked controller matched in the init session dictionary.
- @param isReferrable Boolean representing whether to allow the session to be marked as referred, overriding the default behavior.
- @param callback A callback that is called when the session is opened. This will be called multiple times during the apps life, including any time the app goes through a background / foreground cycle.
- @warning This is not the recommended method of initializing Branch, as you potentially lose deep linking info by not passing the launch options.
- */
-- (void)initSessionAndAutomaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController isReferrable:(BOOL)isReferrable deepLinkHandler:(callbackWithParams)callback;
 
 /**
  Initialize the Branch session with the app launch options and handle the completion with a callback

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -261,24 +261,8 @@ NSString * const BRANCH_PUSH_NOTIFICATION_PAYLOAD_KEY = @"branch";
 
 #pragma mark - InitSession Permutation methods
 
-- (void)initSession {
-    [self initSessionWithLaunchOptions:nil isReferrable:YES explicitlyRequestedReferrable:NO automaticallyDisplayController:NO registerDeepLinkHandler:nil];
-}
-
-- (void)initSessionAndAutomaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController {
-    [self initSessionWithLaunchOptions:nil isReferrable:YES explicitlyRequestedReferrable:NO automaticallyDisplayController:automaticallyDisplayController registerDeepLinkHandler:nil];
-}
-
 - (void)initSessionWithLaunchOptions:(NSDictionary *)options {
     [self initSessionWithLaunchOptions:options isReferrable:YES explicitlyRequestedReferrable:NO automaticallyDisplayController:NO registerDeepLinkHandler:nil];
-}
-
-- (void)initSession:(BOOL)isReferrable {
-    [self initSessionWithLaunchOptions:nil isReferrable:isReferrable explicitlyRequestedReferrable:YES automaticallyDisplayController:NO registerDeepLinkHandler:nil];
-}
-
-- (void)initSessionAndRegisterDeepLinkHandler:(callbackWithParams)callback {
-    [self initSessionWithLaunchOptions:nil isReferrable:YES explicitlyRequestedReferrable:NO automaticallyDisplayController:NO registerDeepLinkHandler:callback];
 }
 
 - (void)initSessionWithLaunchOptions:(NSDictionary *)options andRegisterDeepLinkHandler:(callbackWithParams)callback {
@@ -297,18 +281,6 @@ NSString * const BRANCH_PUSH_NOTIFICATION_PAYLOAD_KEY = @"branch";
     [self initSessionWithLaunchOptions:options isReferrable:YES explicitlyRequestedReferrable:NO automaticallyDisplayController:automaticallyDisplayController registerDeepLinkHandler:nil];
 }
 
-- (void)initSession:(BOOL)isReferrable andRegisterDeepLinkHandler:(callbackWithParams)callback {
-    [self initSessionWithLaunchOptions:nil isReferrable:isReferrable explicitlyRequestedReferrable:YES automaticallyDisplayController:NO registerDeepLinkHandler:callback];
-}
-
-- (void)initSession:(BOOL)isReferrable automaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController {
-    [self initSessionWithLaunchOptions:nil isReferrable:isReferrable explicitlyRequestedReferrable:YES automaticallyDisplayController:automaticallyDisplayController registerDeepLinkHandler:nil];
-}
-
-- (void)initSessionAndAutomaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController deepLinkHandler:(callbackWithParams)callback {
-    [self initSessionWithLaunchOptions:nil isReferrable:YES explicitlyRequestedReferrable:NO automaticallyDisplayController:automaticallyDisplayController registerDeepLinkHandler:callback];
-}
-
 - (void)initSessionWithLaunchOptions:(NSDictionary *)options isReferrable:(BOOL)isReferrable andRegisterDeepLinkHandler:(callbackWithParams)callback {
     [self initSessionWithLaunchOptions:options isReferrable:isReferrable explicitlyRequestedReferrable:YES automaticallyDisplayController:NO registerDeepLinkHandler:callback];
 }
@@ -319,10 +291,6 @@ NSString * const BRANCH_PUSH_NOTIFICATION_PAYLOAD_KEY = @"branch";
 
 - (void)initSessionWithLaunchOptions:(NSDictionary *)options isReferrable:(BOOL)isReferrable automaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController {
     [self initSessionWithLaunchOptions:options isReferrable:isReferrable explicitlyRequestedReferrable:YES automaticallyDisplayController:automaticallyDisplayController registerDeepLinkHandler:nil];
-}
-
-- (void)initSessionAndAutomaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController isReferrable:(BOOL)isReferrable deepLinkHandler:(callbackWithParams)callback {
-    [self initSessionWithLaunchOptions:nil isReferrable:isReferrable explicitlyRequestedReferrable:YES automaticallyDisplayController:automaticallyDisplayController registerDeepLinkHandler:callback];
 }
 
 - (void)initSessionWithLaunchOptions:(NSDictionary *)options automaticallyDisplayDeepLinkController:(BOOL)automaticallyDisplayController isReferrable:(BOOL)isReferrable deepLinkHandler:(callbackWithParams)callback {


### PR DESCRIPTION
@aaustin @ahmednawar we should not have any versions of initSession that don't pass in launchOptions. This will only cause confusion. Our SDK does not function normally without launchOptions.

If anyone is using one of these methods and upgrades SDKs, they will need to switch to a more complete version of initSession. While I in general am highly opposed to forced upgrades, anyone currently using one of these methods has a buggy implementation of Branch.