### PR TITLE
modified method used to get a pointer to the main window

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.m
@@ -104,7 +104,7 @@ NSInteger const ABOUT_30_DAYS_TIME_IN_SECONDS = 60 * 60 * 24 * 30;
     if (SFSafariViewControllerClass) {
         UIViewController * safController = [[SFSafariViewControllerClass alloc] initWithURL:[NSURL URLWithString:urlString]];
         
-        self.secondWindow = [[UIWindow alloc] initWithFrame:[[[[UIApplication sharedApplication] delegate] window] bounds]];
+		self.secondWindow = [[UIWindow alloc] initWithFrame:[[[[UIApplication sharedApplication] windows] firstObject] bounds]];
         UIViewController *windowRootController = [[UIViewController alloc] init];
         self.secondWindow.rootViewController = windowRootController;
         self.secondWindow.windowLevel = UIWindowLevelNormal - 1;


### PR DESCRIPTION
The AppDelegate having a window property is defaulted when creating a new project, but certainly not required.  This adjusts how the pointer to the window is obtained preventing a crash for apps that don't have a window property on their AppDelegate.

Sample stack trace of crash:

```
-[AppDelegate window]: unrecognized selector sent to instance 0x14550cd10

#0	0x0000000181103f48 in objc_exception_throw ()
#1	0x0000000181a9c61c in -[NSObject(NSObject) doesNotRecognizeSelector:] ()
#2	0x0000000181a993e8 in ___forwarding___ ()
#3	0x000000018199d68c in _CF_forwarding_prep_0 ()
#4	0x0000000100369280 in -[BNCStrongMatchHelper presentSafariVCWithBranchKey:] at /Users/ahmed/Documents/git_repos/iOS-Deferred-Deep-Linking-SDK/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.m:107
#5	0x0000000100368f10 in -[BNCStrongMatchHelper createStrongMatchWithBranchKey:] at /Users/ahmed/Documents/git_repos/iOS-Deferred-Deep-Linking-SDK/Branch-SDK/Branch-SDK/BNCStrongMatchHelper.m:66
#6	0x000000010034f180 in -[Branch registerInstallOrOpen:] at /Users/ahmed/Documents/git_repos/iOS-Deferred-Deep-Linking-SDK/Branch-SDK/Branch-SDK/Branch.m:1382
#7	0x0000000181a3afc4 in __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ ()
#8	0x0000000181a3a7e4 in _CFXRegistrationPost ()
#9	0x0000000181a3a564 in ___CFXNotificationPost_block_invoke ()
#10	0x0000000181a9fde4 in -[_CFXNotificationRegistrar find:object:observer:enumerator:] ()
#11	0x000000018197b0f4 in _CFXNotificationPost ()
#12	0x000000018236ad2c in -[NSNotificationCenter postNotificationName:object:userInfo:] ()
#13	0x0000000186810e20 in -[UIApplication _stopDeactivatingForReason:] ()
#14	0x0000000186a2ed20 in __62-[UIApplication _sceneSettingsPostLifecycleEventDiffInspector]_block_invoke1155 ()
#15	0x000000018303cb34 in __52-[FBSSettingsDiffInspector inspectDiff:withContext:]_block_invoke27 ()
#16	0x000000018241a018 in __NSIndexSetEnumerate ()
#17	0x0000000182fc7704 in -[BSSettingsDiff inspectChangesWithBlock:] ()
#18	0x0000000183037b84 in -[FBSSettingsDiff inspectOtherChangesWithBlock:] ()
#19	0x000000018303c90c in -[FBSSettingsDiffInspector inspectDiff:withContext:] ()
#20	0x0000000186a2f5b4 in __70-[UIApplication scene:didUpdateWithDiff:transitionContext:completion:]_block_invoke ()
#21	0x0000000186a2f210 in -[UIApplication scene:didUpdateWithDiff:transitionContext:completion:] ()
#22	0x000000018304b790 in -[FBSSerialQueue _performNext] ()
#23	0x000000018304bb10 in -[FBSSerialQueue _performNextFromRunLoopSource] ()
#24	0x0000000181a4cefc in __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ ()
#25	0x0000000181a4c990 in __CFRunLoopDoSources0 ()
#26	0x0000000181a4a690 in __CFRunLoopRun ()
#27	0x0000000181979680 in CFRunLoopRunSpecific ()
#28	0x0000000182e88088 in GSEventRunModal ()
#29	0x00000001867f0d90 in UIApplicationMain ()
#30	0x00000001002bc680 in main at /Users/joe/DevMango/master/Mango/main.m:15
#31	0x000000018151a8b8 in start ()

```