### PR TITLE
fix deprecation warning when targeting iOS 8

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchUniversalObject.m
+++ b/Branch-SDK/Branch-SDK/BranchUniversalObject.m
@@ -159,7 +159,11 @@
             }
         };
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        // Deprecated in iOS 8.  Safe to hide deprecation warnings as the new completion handler is checked for above
         shareViewController.completionHandler = completion;
+#pragma clang diagnostic pop
     }
     
     UIViewController *presentingViewController;


### PR DESCRIPTION
This fixes https://github.com/BranchMetrics/iOS-Deferred-Deep-Linking-SDK/issues/297

It's safe to hide deprecation warnings on this line as the new completion handler is checked for above.

Cheers!
