### PR TITLE
Marshal's fix for session params

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -363,7 +363,7 @@ NSString * const BRANCH_PREFS_KEY_BRANCH_VIEW_USAGE_CNT = @"bnc_branch_view_usag
 }
 
 - (NSString *)sessionParams {
-    if (_sessionParams) {
+    if (!_sessionParams) {
         _sessionParams = [self readStringFromDefaults:BRANCH_PREFS_KEY_SESSION_PARAMS];
     }
     


### PR DESCRIPTION
@pbcorriganBranch

Marshal’s fix on Cordova for the core SDK. We seem to only read from
defaults when the sessionParams are non-null, which is wrong.

I can’t even think of an edge case where this would happen, which is
probably why we’ve never encountered it.