### PR TITLE
Add CocoaPod podspec without IDFA

### DIFF
--- a/Branch-no-idfa.podspec
+++ b/Branch-no-idfa.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |s|
+  s.name             = "Branch"
+  s.version          = "0.12.1"
+  s.summary          = "Create an HTTP URL for any piece of content in your app"
+  s.description      = <<-DESC
+- Want the highest possible conversions on your sharing feature?
+- Want to measure the k-factor of your invite feature?
+- Want a whole referral program in 10 lines of code, with automatic user-user attribution and rewarding?
+- Want to pass data (deep link) from a URL across install and open?
+- Want custom onboarding post install?
+- Want it all for free?
+
+Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it's really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.
+                       DESC
+  s.homepage         = "https://branch.io"
+  s.license          = 'Proprietary'
+  s.author           = { "Branch" => "support@branch.io" }
+  s.source           = { :git => "https://github.com/BranchMetrics/iOS-Deferred-Deep-Linking-SDK.git", :tag => s.version.to_s }
+  s.social_media_url = 'https://www.linkedin.com/company/3813083'
+
+  s.platform     = :ios, '6.0'
+  s.requires_arc = true
+
+  s.source_files = "Branch-SDK/Branch-SDK/*.{h,m}", "Branch-SDK/Fabric/*.h", "Branch-SDK/Branch-SDK/Requests/*.{h,m}"
+
+  s.frameworks = 'CoreTelephony', 'MobileCoreServices'
+end

--- a/Branch-no-idfa.podspec
+++ b/Branch-no-idfa.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name             = "Branch"
+  s.name             = "Branch-no-idfa"
   s.version          = "0.12.1"
   s.summary          = "Create an HTTP URL for any piece of content in your app"
   s.description      = <<-DESC


### PR DESCRIPTION
As a developer I would like to be able to install the SDK using CocoaPods and without IDFA.
In the docs you pin point correctly [how to achieve this](https://dev.branch.io/getting-started/sdk-integration-guide/guide/ios/#submitting-to-the-app-store).

I added a new podspec that any developer will be able to use for installing the SDK without IDFA. This will allow us to keep the SDK updated easily